### PR TITLE
fix(autoload): autoload needs to happen before use of use.

### DIFF
--- a/phalcon
+++ b/phalcon
@@ -10,6 +10,14 @@
  * the LICENSE file that was distributed with this source code.
  */
 
+// Autoload need to happen before the use of use.
+try {
+    require dirname(__FILE__) . '/bootstrap/autoload.php';
+} catch (\Throwable $e) {
+    fwrite(STDERR, Color::error($e->getMessage()) . PHP_EOL);
+    exit(1);
+}
+
 use Phalcon\DevTools\Commands\Builtin\AllModels;
 use Phalcon\DevTools\Commands\Builtin\Console;
 use Phalcon\DevTools\Commands\Builtin\Controller;
@@ -30,8 +38,6 @@ use Phalcon\DevTools\Version;
 use Phalcon\Events\Manager as EventsManager;
 
 try {
-    require dirname(__FILE__) . '/bootstrap/autoload.php';
-
     $vendor = sprintf('Phalcon DevTools (%s)', (new Version())->get());
     print PHP_EOL . Color::colorize($vendor, Color::FG_GREEN, Color::AT_BOLD) . PHP_EOL . PHP_EOL;
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines][:contrib:]
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR

Small description of change:

Before the usage of `vendor/bin/phalcon` raised an exception:

```bash
www-data@ad3f5c1317e5:/app$ vendor/bin/phalcon
PHP Fatal error:  Uncaught Error: Class "Phalcon\DevTools\Script\Color" not found in /app/vendor/phalcon/devtools/phalcon:72
Stack trace:
#0 {main}
thrown in /app/vendor/phalcon/devtools/phalcon on line 72
```

Because the autoload happened after the use of use statements.

Thanks

[:contrib:]: https://github.com/phalcon/phalcon-devtools/blob/master/CONTRIBUTING.md
